### PR TITLE
Fix initial screen

### DIFF
--- a/public/ticker/javascripts/controllers/ticker-controller.js
+++ b/public/ticker/javascripts/controllers/ticker-controller.js
@@ -12,15 +12,15 @@ define([
     function($scope, $interval, $document, phraseService, socketService, clientService, countdownService) {
       socketService.initialize();
 
-      $scope.currentPhrase = phraseService.getCurrentPhrase();
+      $scope.getCurrentPhrase = phraseService.getCurrentPhrase;
 
       $scope.showNext = function() {
-        $scope.currentPhrase = phraseService.refreshPhrases();
+        phraseService.nextPhrase();
         countdownService.restart();
       };
 
       $scope.showPrevious = function() {
-        $scope.currentPhrase = phraseService.previousPhrase();
+        phraseService.previousPhrase();
         countdownService.restart();
       };
 

--- a/public/ticker/javascripts/directives/countdown.js
+++ b/public/ticker/javascripts/directives/countdown.js
@@ -7,7 +7,8 @@ define([
       replace: true,
       templateUrl: 'ticker/templates/countdown.html',
       scope: {
-        onFinish: '&onFinish'
+        onFinish: '&onFinish',
+        isPaused: '='
       },
       controller: 'countdownController'
     };
@@ -24,15 +25,17 @@ define([
       countdownService.setMaximum(countdownMax);
 
       var countdownToRefresh = function() {
-        countdownService.countDown();
+        if (!$scope.isPaused) {
+          countdownService.countDown();
 
-        var countdownValue = countdownService.getValue();
-        if (countdownValue <= 0) {
-          $scope.onFinish();
-          countdownService.restart();
+          var countdownValue = countdownService.getValue();
+          if (countdownValue <= 0) {
+            $scope.onFinish();
+            countdownService.restart();
+          }
+
+          $scope.percent = (countdownValue * 100) / countdownMax;
         }
-
-        $scope.percent = (countdownValue * 100) / countdownMax;
       };
 
       $interval(countdownToRefresh, 1000 / smoothness);

--- a/public/ticker/javascripts/services/phrase-service.js
+++ b/public/ticker/javascripts/services/phrase-service.js
@@ -21,11 +21,11 @@ define([
     var addPhrase = function(phrase) {
       phrases.push(phrase);
       if (phrases.length === 1) {
-        refreshPhrases();
+        nextPhrase();
       }
     };
 
-    var refreshPhrases = function() {
+    var nextPhrase = function() {
       if (phrases.length > 0) {
         currentPhraseIndex++;
 
@@ -33,8 +33,6 @@ define([
           retireOldPhrases();
           currentPhraseIndex = 0;
         }
-
-        return phrases[currentPhraseIndex];
       }
     };
 
@@ -46,8 +44,6 @@ define([
           retireOldPhrases();
           currentPhraseIndex = phrases.length - 1;
         }
-
-        return phrases[currentPhraseIndex];
       }
     };
 
@@ -90,7 +86,7 @@ define([
       getCurrentPhrase: getCurrentPhrase,
       setPhrases: setPhrases,
       addPhrase: addPhrase,
-      refreshPhrases: refreshPhrases,
+      nextPhrase: nextPhrase,
       previousPhrase: previousPhrase,
       retireOldPhrases: retireOldPhrases
     };

--- a/public/ticker/javascripts/services/socket-service.js
+++ b/public/ticker/javascripts/services/socket-service.js
@@ -21,7 +21,7 @@ define([
         if (_.isArray(data)) {
           phraseService.setPhrases(data);
           phraseService.retireOldPhrases();
-          phraseService.refreshPhrases();
+          phraseService.nextPhrase();
         }
       });
 

--- a/public/ticker/templates/ticker.html
+++ b/public/ticker/templates/ticker.html
@@ -5,7 +5,7 @@
     <div countdown on-finish="showNext()"></div>
   </div>
 
-  <div phrase-box phrase="currentPhrase"></div>
+  <div phrase-box phrase="getCurrentPhrase()"></div>
 
   <div info-pane></div>
 

--- a/public/ticker/templates/ticker.html
+++ b/public/ticker/templates/ticker.html
@@ -2,7 +2,7 @@
   <div id="header" ng-class="{ 'header-expanded': isExpanded }" ng-mouseenter="isExpanded = true" ng-mouseleave="isExpanded = false">
     <div phrase-creator on-phrase-added="isExpanded = false"></div>
     <div id="add_container"><div id="add_q_bttn"></div></div>
-    <div countdown on-finish="showNext()"></div>
+    <div countdown on-finish="showNext()" is-paused="!getCurrentPhrase()"></div>
   </div>
 
   <div phrase-box phrase="getCurrentPhrase()"></div>


### PR DESCRIPTION
I noticed a bug where when the app first loads and a quote is added, it doesn't automatically progress to it, so I fixed that. I also added a means to pause the ticker; right now it's only used to pause the countdown when there's no quotes in the board but it could eventually be used to pause it if we wanted.
